### PR TITLE
feat(retrier): per-attempt error tracking, early stop, and init guards

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -1,0 +1,73 @@
+# PRD: go-again Retrier Hardening
+
+## Context
+
+`go-again` retries a function with exponential backoff, jitter, and timeout. It provides a registry for temporary errors, cancellation support, and error aggregation. The goal is to fix correctness issues and align documentation with current APIs without changing the public surface.
+
+## Goals
+
+- Ensure `Retrier.Do` is safe for concurrent calls.
+- Return early on non-temporary errors when a temporary-error list is supplied.
+- Avoid panics when `Retrier` is constructed without `NewRetrier`.
+- Make timeout errors detectable via `errors.Is`.
+- Align README examples and API description with the code.
+
+## Non-Goals
+
+- Change retry semantics when `temporaryErrors` are omitted.
+- Redesign backoff or introduce new retry strategies.
+- Add new public APIs beyond documentation updates.
+
+## Current Feature Inventory
+
+- Configurable retry policy: max retries, backoff factor, interval, jitter, timeout.
+- Temporary error registry with defaults and custom registration.
+- Cancellation via caller context and `Retrier.Cancel`/`Retrier.Stop`.
+- Error aggregation via `Errors` (attempt trace + `Join`).
+- `DoWithResult` helper, hooks, and optional logging.
+
+## Gaps / Bugs
+
+- Shared mutable error field introduces data races under concurrent `Do` calls.
+- Non-temporary errors can still append `ErrMaxRetriesReached`.
+- `Retrier` built without `NewRetrier` can panic due to nil timer/context/registry.
+- Timeout errors are not wrapped with `ErrTimeoutReached`, so `errors.Is` fails.
+- README examples and `Errors` struct definition are out of date.
+
+## Requirements
+
+### Functional
+
+- `Do` uses per-call error state only (no shared fields).
+- Non-temporary errors return immediately when a temporary list is provided.
+- `Do` initializes missing internals (timer pool, registry, context, pool) safely.
+- Timeout path wraps `ErrTimeoutReached` as the cause.
+- README reflects actual `Errors` fields and registry usage.
+
+### Non-Functional
+
+- Preserve current public API and default behavior.
+- Maintain performance characteristics (no per-attempt allocations beyond today).
+
+## Proposed Changes
+
+- Remove reliance on `Retrier.err`; use local variables per call.
+- Add internal initialization to avoid nil timer/context/registry/pool.
+- Wrap timeouts with `ErrTimeoutReached` and include attempt + last error in message.
+- Return early on non-temporary errors when a list is provided.
+- Update README snippets and API notes to match current code.
+
+## Test Plan
+
+- Add a test verifying non-temporary error returns early (no max-retries marker).
+- Add a test ensuring manually constructed `Retrier` does not panic in `Do`.
+- Assert `errors.Is(err, ErrTimeoutReached)` is true on timeouts.
+- Run `go test ./...`.
+
+## Rollout
+
+arly on non-temporary errors when a list is provided.
+
+arly on non-temporary errors when a list is provided.
+
+- Update README snippets and API notes to match current code.

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 [![Go](https://github.com/hyp3rd/go-again/actions/workflows/go.yml/badge.svg)][build-link] [![CodeQL](https://github.com/hyp3rd/go-again/actions/workflows/codeql.yml/badge.svg)][codeql-link]
 
 `go-again` **thread safely** wraps a given function and executes it until it returns a nil error or exceeds the maximum number of retries.
-The configuration consists of the maximum number of retries, the interval, a jitter to add a randomized backoff, the timeout, and a registry to store errors that you consider temporary, hence worth a retry.
+The configuration consists of the maximum number of retries (after the first attempt), the interval, a jitter to add a randomized backoff, the timeout, and a registry to store errors that you consider temporary, hence worth a retry.
 
-The `Do` method takes a context, a function, and an optional list of `temporary errors` as arguments. It supports cancellation from the context and a channel invoking the `Cancel()` function.
+The `Do` method takes a context, a function, and an optional list of `temporary errors` as arguments. If the list is omitted and the registry has entries, the registry is used as the default filter; if the registry is empty, all errors are retried. It supports cancellation from the context and a channel invoking the `Cancel()` function; long-running operations should observe the context inside the retryable function.
 The returned type is `Errors` which contains the list of errors returned at each attempt and the last error returned by the function.
 
 ```golang
@@ -18,7 +18,7 @@ type Errors struct {
 }
 ```
 
-When you pass a list of temporary errors to `Do`, retries only happen when the error matches that list. The registry is a convenience store for temporary errors you want to pass to `Do`:
+When you pass a list of temporary errors to `Do`, retries only happen when the error matches that list. The registry is a convenience store for temporary errors you want to pass to `Do`, or to use as the default filter when the list is omitted:
 
 ```go
     // Init with defaults.
@@ -47,7 +47,7 @@ When you pass a list of temporary errors to `Do`, retries only happen when the e
     }
 ```
 
-Should you retry regardless of the error returned, call `Do` without passing any temporary errors:
+Should you retry regardless of the error returned, call `Do` without passing any temporary errors and keep the registry empty:
 
 ```go
     var retryCount int

--- a/options.go
+++ b/options.go
@@ -15,7 +15,7 @@ func applyOptions(retrier *Retrier, options ...Option) {
 	}
 }
 
-// WithMaxRetries returns an option that sets the maximum number of retries.
+// WithMaxRetries returns an option that sets the maximum number of retries after the first attempt.
 func WithMaxRetries(num int) Option {
 	return func(retrier *Retrier) {
 		retrier.MaxRetries = num


### PR DESCRIPTION
•  Track errors per attempt (populate Errors.Attempts); remove shared r.err usage. •  Return early when a non-temporary error is encountered (when a temporary-error list/registry is provided). •  Wrap timeouts with ErrTimeoutReached and include attempt context. •  Add ensureInitialized/ensureContext; default registry, logger, timer pool; support manual initialization. •  Tests: cover early-stop behavior, timeouts, and manual init (e.g., TestDo_NonTemporaryStopsEarly, TestDo_ManualRetrierInitialization). •  Docs: add PRD for Retrier Hardening; update README and examples (temporary error registry usage).

BREAKING CHANGE: Errors.Retries renamed to Errors.Attempts. Update usages and expectations: •  Use Errors.Attempts for attempt traces.
•  Register temporary errors via retrier.Registry.RegisterTemporaryError. •  Expect timeout errors as ErrTimeoutReached and max-retries errors wrapped by ErrMaxRetriesReached.